### PR TITLE
msm8916-common: overlay: Enable panic detection mode.

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -279,4 +279,10 @@
     <!-- Configuration to support SIM contact batch operation -->
     <bool name="config_sim_phonebook_batch_operation">false</bool>
 
+    <!-- Control the behavior when the user panic presses the back button.
+            0 - Nothing
+            1 - Go to home
+    -->
+    <integer name="config_backPanicBehavior">1</integer>
+    
 </resources>


### PR DESCRIPTION
* Google introduced a security feature in Android 7.1+ to bypass rogue application from hijacking the user’s screen and prevent the user from leaving.
* Source - https://www.xda-developers.com/android-7-1-has-a-panic-detection-mode-that-detects-frantic-back-button-presses/