### PR TITLE
Add ANT+ Support

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -46,6 +46,9 @@ BOARD_MKBOOTIMG_ARGS := --ramdisk_offset 0x01000000 --tags_offset 0x00000100
 TARGET_KERNEL_ARCH := arm
 TARGET_KERNEL_SOURCE := kernel/motorola/msm8916
 
+# ANT+
+BOARD_ANT_WIRELESS_DEVICE := "qualcomm-smd"
+
 # Audio
 BOARD_USES_ALSA_AUDIO := true
 USE_CUSTOM_AUDIO_POLICY := 1

--- a/msm8916.mk
+++ b/msm8916.mk
@@ -50,6 +50,15 @@ PRODUCT_COPY_FILES += \
 # Screen density
 PRODUCT_AAPT_CONFIG := normal
 
+# ANT+
+PRODUCT_PACKAGES += \
+        com.dsi.ant.antradio_library \
+        AntHalService \
+        libantradio \
+        
+PRODUCT_COPY_FILES += \
+        external/ant-wireless/antradio-library/com.dsi.ant.antradio_library.xml:system/etc/permissions/com.dsi.ant.antradio_library.xml \
+
 # Audio
 PRODUCT_PACKAGES += \
     audiod \

--- a/msm8916.mk
+++ b/msm8916.mk
@@ -21,6 +21,7 @@ DEVICE_PACKAGE_OVERLAYS += $(LOCAL_PATH)/overlay
 
 # These are the hardware-specific features
 PRODUCT_COPY_FILES += \
+    external/ant-wireless/antradio-library/com.dsi.ant.antradio_library.xml:system/etc/permissions/com.dsi.ant.antradio_library.xml \
     frameworks/native/data/etc/android.hardware.audio.low_latency.xml:system/etc/permissions/android.hardware.audio.low_latency.xml \
     frameworks/native/data/etc/android.hardware.bluetooth.xml:system/etc/permissions/android.hardware.bluetooth.xml \
     frameworks/native/data/etc/android.hardware.bluetooth_le.xml:system/etc/permissions/android.hardware.bluetooth_le.xml \
@@ -55,9 +56,6 @@ PRODUCT_PACKAGES += \
         com.dsi.ant.antradio_library \
         AntHalService \
         libantradio \
-        
-PRODUCT_COPY_FILES += \
-        external/ant-wireless/antradio-library/com.dsi.ant.antradio_library.xml:system/etc/permissions/com.dsi.ant.antradio_library.xml \
 
 # Audio
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
I have tested and confirmed ANT+ Radio capability for the Osprey under LineageOS14.1 by flashing a zip with associated ANT+ files from the BQ Aquaris E5, which shares the same MSM8916 chip. BQ_msm8916-common uses the "qualcomm-cmd" tag. 

This should enable native ANT+ support for motorola msm8916 devices if desired, by downloading ANT Radio Service and ANT+ Plugins Service apps from the play store (minimizes system apps). More information here: https://github.com/ant-wireless/ANT_in_Android

So far the flashable zip enables ANT+ in osprey, harpia, and surnia, so would assume all devices using motorola_msm8916-common would benefit.

I haven't tested in a compiled ROM, as I don't have compiling capabilities, but this same feature was successfully enabled for motorola_msm8226-common for falcon, peregrine, and others, with identical commits.

Please feel free to edit this down to a single commit & no need for credit. I didn't author anything original here.
  
  